### PR TITLE
Fix compiler warnings for type safety and function contracts

### DIFF
--- a/main.c
+++ b/main.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
             }
             uint64_t s2 = ll_to_s2(latE6, lonE6);
             const char *result = s2_to_placewords(s2);
-            printf("s2=%016lX\n", s2);
+            printf("s2=%016llX\n", s2);
             printf("latE6=%d lonE6=%d\n", latE6, lonE6);
             printf("lat=%.6f lon=%.6f\n", latE6 / 1e6, lonE6 / 1e6);
             printf("%s\n", result);
@@ -106,14 +106,14 @@ int main(int argc, char **argv) {
             if (strchr(argv[1], ':') != NULL) {
                uint64_t s2 = placewords_to_s2(argv[1]);
                int *result = s2_to_ll(s2);
-               printf("s2=%016lX\n", s2);
+               printf("s2=%016llX\n", s2);
                printf("latE6=%d lonE6=%d\n", result[0], result[1]);
                printf("lat=%.6f lon=%.6f\n", result[0] / 1e6, result[1] / 1e6);
             }
             else {
                uint64_t s2 = dehex(argv[1]);
                int *result = s2_to_ll(s2);
-               printf("s2=%016lX\n", s2);
+               printf("s2=%016llX\n", s2);
                printf("latE6=%d lonE6=%d\n", result[0], result[1]);
                printf("lat=%.6f lon=%.6f\n", result[0] / 1e6, result[1] / 1e6);
                const char *words = s2_to_placewords(s2);

--- a/words.c
+++ b/words.c
@@ -148,6 +148,7 @@ int init_words(const char *language) {
    printf("hash: empty=%d average=%f biggest=%d smallest=%d zero=%d\n",
          empty, (float)sum/(float)HASH_SIZE, biggest, smallest, hash_count[0]);
 #endif
+   return 0;
 }
 
 char *ordinal_to_word(int ordinal) {


### PR DESCRIPTION
## Summary
• Fixed missing return statement in init_words() function (words.c:151)
• Updated printf format specifiers from %016lX to %016llX for uint64_t values (main.c:98,109,116)

## Environment
- **OS**: Darwin 24.6.0 (macOS arm64)
- **Compiler**: Apple clang version 17.0.0 (clang-1700.0.13.5)

## Build Output

### Before (4 warnings):
```
gcc -c -g -O words.c
words.c:151:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  151 | }
      | ^
1 warning generated.
gcc -c -g -O main.c
main.c:98:35: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
   98 |             printf("s2=%016lX\n", s2);
      |                        ~~~~~~     ^~
      |                        %016llX
main.c:109:38: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
  109 |                printf("s2=%016lX\n", s2);
      |                           ~~~~~~     ^~
      |                           %016llX
main.c:116:38: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
  116 |                printf("s2=%016lX\n", s2);
      |                           ~~~~~~     ^~
      |                           %016llX
3 warnings generated.
```

### After (0 warnings):
```
gcc -c -g -O placewords.c
gcc -c -g -O words.c
gcc -c -g -O s2.c
gcc -c -g -O main.c
gcc -g -O placewords.o words.o s2.o main.o -lm -o placewords
```

Alternative considered: using PRIx64 macro for full portability, but %016llX is sufficient for current target platforms and maintains code simplicity.

🤖 Generated with [Claude Code](https://claude.ai/code)